### PR TITLE
HPS metric feature

### DIFF
--- a/backend/src/models/CharacterLeaderboard.ts
+++ b/backend/src/models/CharacterLeaderboard.ts
@@ -42,6 +42,7 @@ export interface ICharacterLeaderboard extends Document {
   specName: string;
   bestSpecName: string;
   role: "dps" | "healer" | "tank";
+  metric: "dps" | "hps";
   ilvl: number;
 
   // Primary sort key
@@ -98,6 +99,7 @@ const CharacterLeaderboardSchema: Schema = new Schema(
     specName: { type: String, required: true },
     bestSpecName: { type: String, default: "" },
     role: { type: String, enum: ["dps", "healer", "tank"], required: true },
+    metric: { type: String, enum: ["dps", "hps"], required: true, default: "dps", index: true },
     ilvl: { type: Number, default: 0 },
 
     score: { type: Number, required: true },
@@ -124,7 +126,7 @@ const CharacterLeaderboardSchema: Schema = new Schema(
 );
 
 // ── Unique constraint ──────────────────────────────────────────────
-CharacterLeaderboardSchema.index({ zoneId: 1, difficulty: 1, type: 1, encounterId: 1, partition: 1, wclCanonicalCharacterId: 1 }, { unique: true });
+CharacterLeaderboardSchema.index({ zoneId: 1, difficulty: 1, type: 1, encounterId: 1, partition: 1, metric: 1, wclCanonicalCharacterId: 1 }, { unique: true });
 
 // ── Primary leaderboard query (no optional filters) ────────────────
 CharacterLeaderboardSchema.index({
@@ -133,6 +135,7 @@ CharacterLeaderboardSchema.index({
   type: 1,
   encounterId: 1,
   partition: 1,
+  metric: 1,
   score: -1,
 });
 

--- a/backend/src/models/Ranking.ts
+++ b/backend/src/models/Ranking.ts
@@ -25,6 +25,7 @@ export interface IRanking extends Document {
   specName: string;
   role: "dps" | "healer" | "tank";
   bestSpecName: string;
+  metric: "dps" | "hps";
 
   rankPercent: number;
   medianPercent: number;
@@ -72,6 +73,7 @@ const RankingSchema: Schema = new Schema(
 
     specName: { type: String, required: true },
     bestSpecName: { type: String, required: true },
+    metric: { type: String, enum: ["dps", "hps"], required: true, default: "dps", index: true },
     role: {
       type: String,
       enum: ["dps", "healer", "tank"],
@@ -91,7 +93,7 @@ const RankingSchema: Schema = new Schema(
   { timestamps: true },
 );
 
-// Unique index per partition (allows same boss/spec across partitions)
+// Unique index per partition + metric (allows same boss/spec to have both dps and hps docs)
 RankingSchema.index(
   {
     characterId: 1,
@@ -100,6 +102,7 @@ RankingSchema.index(
     partition: 1,
     "encounter.id": 1,
     specName: 1,
+    metric: 1,
   },
   { unique: true },
 );

--- a/backend/src/routes/character-rankings.ts
+++ b/backend/src/routes/character-rankings.ts
@@ -9,6 +9,7 @@ import cacheService from "../services/cache.service";
 const router = Router();
 
 const ALLOWED_ROLES = new Set(["dps", "healer", "tank"] as const);
+const ALLOWED_METRICS = new Set(["dps", "hps"] as const);
 const MYTHIC_DIFFICULTY = 5;
 
 const parseNumberQuery = (value: unknown): number | undefined => {
@@ -134,6 +135,9 @@ router.get("/", async (req: Request, res: Response) => {
     const roleRaw = parseStringQuery(req.query.role)?.toLowerCase();
     const role = roleRaw as "dps" | "healer" | "tank" | undefined;
 
+    const metricRaw = parseStringQuery(req.query.metric)?.toLowerCase() ?? "dps";
+    const metric = metricRaw as "dps" | "hps";
+
     if (encounterId !== undefined && !Number.isFinite(encounterId)) {
       return res.status(400).json({ error: "Invalid encounterId" });
     }
@@ -152,6 +156,9 @@ router.get("/", async (req: Request, res: Response) => {
     if (role !== undefined && !ALLOWED_ROLES.has(role)) {
       return res.status(400).json({ error: "Invalid role" });
     }
+    if (!ALLOWED_METRICS.has(metric)) {
+      return res.status(400).json({ error: "Invalid metric" });
+    }
     if (characterName !== undefined && characterName.length > 64) {
       return res.status(400).json({ error: "Invalid characterName" });
     }
@@ -165,6 +172,7 @@ router.get("/", async (req: Request, res: Response) => {
       classId,
       specName,
       role,
+      metric,
       partition,
       page,
       limit,

--- a/backend/src/services/background-guild-processor.service.ts
+++ b/backend/src/services/background-guild-processor.service.ts
@@ -704,13 +704,13 @@ class BackgroundGuildProcessor {
       await queueItem.updateProgress(0, 0, 0, totalFights);
 
       let fightsProcessed = 0;
-      let totalCharactersSaved = 0;
+      const seenCanonicalIDs = new Set<string>();
 
       for (const fight of mythicKills) {
         // Check rate limit before each API call
         if (!rateLimitService.canProceedBackground()) {
           guildLog.info(`[CharacterRescan] Rate limit threshold reached, pausing...`);
-          await queueItem.updateProgress(fightsProcessed, totalCharactersSaved, fightsProcessed);
+          await queueItem.updateProgress(fightsProcessed, seenCanonicalIDs.size, fightsProcessed);
           await queueItem.pause();
           await rateLimitService.waitForReset();
           await queueItem.resume();
@@ -719,7 +719,7 @@ class BackgroundGuildProcessor {
 
         if (this.isPaused) {
           guildLog.info(`[CharacterRescan] Manually paused at fight ${fightsProcessed}/${totalFights}`);
-          await queueItem.updateProgress(fightsProcessed, totalCharactersSaved, fightsProcessed);
+          await queueItem.updateProgress(fightsProcessed, seenCanonicalIDs.size, fightsProcessed);
           await queueItem.pause();
           return;
         }
@@ -740,11 +740,11 @@ class BackgroundGuildProcessor {
               guildName,
               guildRealm,
             });
+            seenCanonicalIDs.add(char.canonicalID);
           }
 
-          totalCharactersSaved += rankedChars.length;
           fightsProcessed++;
-          await queueItem.updateProgress(fightsProcessed, totalCharactersSaved, fightsProcessed, totalFights);
+          await queueItem.updateProgress(fightsProcessed, seenCanonicalIDs.size, fightsProcessed, totalFights);
 
           // Delay between API calls
           await new Promise((resolve) => setTimeout(resolve, this.config.fetchDelay));
@@ -757,7 +757,7 @@ class BackgroundGuildProcessor {
       }
 
       await queueItem.markCompleted();
-      guildLog.info(`[CharacterRescan] Completed: ${fightsProcessed} fights processed, ${totalCharactersSaved} characters saved`);
+      guildLog.info(`[CharacterRescan] Completed: ${fightsProcessed} fights processed, ${seenCanonicalIDs.size} unique characters saved`);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "Unknown error";
       guildLog.error(`[CharacterRescan] Fatal error: ${errorMessage}`);

--- a/backend/src/services/character.service.ts
+++ b/backend/src/services/character.service.ts
@@ -124,6 +124,7 @@ export type CharacterRankingRow = {
   context: {
     zoneId: number;
     difficulty: number;
+    metric: "dps" | "hps";
     partition?: number;
     encounterId: number | null;
     specName?: string;
@@ -465,6 +466,7 @@ class CharacterService {
                   difficulty: MYTHIC_DIFFICULTY,
                   partition,
                   specName: specSlug,
+                  metric: "dps",
                 });
                 logger.debug(`[CharacterRankings] No rankings for ${char.name} (${char.realm}) [spec: ${specSlug}]`);
                 continue;
@@ -481,6 +483,7 @@ class CharacterService {
                   difficulty: MYTHIC_DIFFICULTY,
                   partition: zoneRankings.partition,
                   specName: specSlug,
+                  metric: "dps",
                 });
                 logger.debug(`[CharacterRankings] No rankings for ${char.name} (${char.realm}) [spec: ${specSlug}]`);
                 continue;
@@ -497,6 +500,7 @@ class CharacterService {
                 difficulty: MYTHIC_DIFFICULTY,
                 partition: zoneRankings.partition,
                 specName: specSlug,
+                metric: "dps",
               }).lean();
 
               const freshPoints = allStarsEntries.reduce((sum, a) => sum + (a.points ?? 0), 0);
@@ -538,6 +542,7 @@ class CharacterService {
                     partition: rankingPartition,
                     "encounter.id": r.encounter.id,
                     specName: specSlug,
+                    metric: "dps",
                   },
                   {
                     characterId: char._id,
@@ -551,6 +556,7 @@ class CharacterService {
                     zoneId: CURRENT_TIER_ID,
                     difficulty: MYTHIC_DIFFICULTY,
                     partition: rankingPartition,
+                    metric: "dps",
 
                     encounter: {
                       id: r.encounter.id,
@@ -582,6 +588,185 @@ class CharacterService {
               }
 
               logger.info(`[CharacterRankings] Updated rankings for ${char.name} (${char.realm}) [spec: ${specSlug}]`);
+            }
+
+            // ── HPS rankings for healer specs ─────────────────────────
+            const healerSpecSlugs = specSlugs.filter((slug) => classSpecMap[slug] === "healer");
+
+            if (healerSpecSlugs.length > 0) {
+              if (rateLimitService.getPercentUsed() >= RATE_LIMIT_PAUSE_PERCENT) {
+                const resetMs = rateLimitService.getTimeUntilReset();
+                logger.info(
+                  `[CharacterRankings] Rate limit at ${rateLimitService.getPercentUsed().toFixed(1)}%, pausing for ${Math.ceil(resetMs / 1000)}s before HPS query`,
+                );
+                await rateLimitService.waitForReset();
+                logger.info(`[CharacterRankings] Rate limit reset, resuming`);
+              }
+
+              const hpsSpecAliasFields = healerSpecSlugs.map((slug) => {
+                const wclName = toWclSpecName(slug);
+                const alias = toSpecAlias(slug);
+                return `${alias}: zoneRankings(zoneID: $zoneID, difficulty: ${MYTHIC_DIFFICULTY}, metric: hps, compare: Rankings, timeframe: Historical, partition: ${partition}, specName: "${wclName}")`;
+              });
+
+              const hpsQuery = `
+                query($serverSlug: String!, $serverRegion: String!, $characterName: String!, $zoneID: Int!) {
+                  rateLimitData {
+                    limitPerHour
+                    pointsSpentThisHour
+                    pointsResetIn
+                  }
+                  characterData {
+                    character(
+                      name: $characterName,
+                      serverSlug: $serverSlug,
+                      serverRegion: $serverRegion
+                    ) {
+                      id
+                      canonicalID
+                      name
+                      classID
+                      hidden
+                      ${hpsSpecAliasFields.join("\n                      ")}
+                    }
+                  }
+                }
+              `;
+
+              processedCount += 1;
+
+              const hpsResult = await wclService.query<IWarcraftLogsResponse>(hpsQuery, variables);
+              const hpsCharacter = hpsResult.characterData?.character;
+
+              if (hpsCharacter && !hpsCharacter.hidden) {
+                for (const specSlug of healerSpecSlugs) {
+                  const alias = toSpecAlias(specSlug);
+                  const hpsZoneRankings = (hpsCharacter as Record<string, unknown>)[alias] as IWarcraftLogsZoneRankings | null;
+
+                  if (!hpsZoneRankings || (hpsZoneRankings as any).error) {
+                    await Ranking.deleteMany({
+                      characterId: char._id,
+                      zoneId: CURRENT_TIER_ID,
+                      difficulty: MYTHIC_DIFFICULTY,
+                      partition,
+                      specName: specSlug,
+                      metric: "hps",
+                    });
+                    logger.debug(`[CharacterRankings] No HPS rankings for ${char.name} (${char.realm}) [spec: ${specSlug}]`);
+                    continue;
+                  }
+
+                  const hpsAllStarsEntries = hpsZoneRankings.allStars ?? [];
+                  const hpsRankingsEntries = hpsZoneRankings.rankings ?? [];
+
+                  if (hpsAllStarsEntries.length === 0 && hpsRankingsEntries.length === 0) {
+                    await Ranking.deleteMany({
+                      characterId: char._id,
+                      zoneId: CURRENT_TIER_ID,
+                      difficulty: MYTHIC_DIFFICULTY,
+                      partition: hpsZoneRankings.partition,
+                      specName: specSlug,
+                      metric: "hps",
+                    });
+                    logger.debug(`[CharacterRankings] No HPS rankings for ${char.name} (${char.realm}) [spec: ${specSlug}]`);
+                    continue;
+                  }
+
+                  const existingHpsRankings = await Ranking.find({
+                    characterId: char._id,
+                    zoneId: CURRENT_TIER_ID,
+                    difficulty: MYTHIC_DIFFICULTY,
+                    partition: hpsZoneRankings.partition,
+                    specName: specSlug,
+                    metric: "hps",
+                  }).lean();
+
+                  const freshHpsPoints = hpsAllStarsEntries.reduce((sum, a) => sum + (a.points ?? 0), 0);
+                  const freshHpsPossiblePoints = hpsAllStarsEntries.reduce((sum, a) => sum + (a.possiblePoints ?? 0), 0);
+                  const storedHpsPoints = existingHpsRankings.reduce((sum, r: any) => sum + (r.allStars?.points ?? 0), 0);
+                  const storedHpsPossiblePoints = existingHpsRankings.reduce((sum, r: any) => sum + (r.allStars?.possiblePoints ?? 0), 0);
+
+                  const hpsAllStarsChanged = freshHpsPoints !== storedHpsPoints || freshHpsPossiblePoints !== storedHpsPossiblePoints;
+
+                  const freshHpsFingerprint = hpsRankingsEntries
+                    .map((r) => `${r.encounter.id}:${r.bestAmount ?? 0}:${r.rankPercent ?? 0}:${r.totalKills ?? 0}`)
+                    .sort()
+                    .join("|");
+                  const storedHpsFingerprint = existingHpsRankings
+                    .map((r: any) => `${r.encounter?.id}:${r.bestAmount ?? 0}:${r.rankPercent ?? 0}:${r.totalKills ?? 0}`)
+                    .sort()
+                    .join("|");
+
+                  const hpsHasChanged = existingHpsRankings.length === 0 || hpsAllStarsChanged || freshHpsFingerprint !== storedHpsFingerprint;
+
+                  if (!hpsHasChanged) {
+                    logger.debug(`[CharacterRankings] No HPS changes for ${char.name} (${char.realm}) [spec: ${specSlug}]`);
+                    continue;
+                  }
+
+                  for (const r of hpsRankingsEntries) {
+                    const rankingSpecSlug = r.spec ? slugifySpecName(r.spec) : specSlug;
+                    const role = resolveRole(char.classID, rankingSpecSlug);
+                    const normalizedBestSpecName = r.bestSpec ? slugifySpecName(r.bestSpec) : rankingSpecSlug;
+                    const rankingPartition = r.allStars?.partition ?? hpsZoneRankings.partition ?? partition;
+
+                    await Ranking.findOneAndUpdate(
+                      {
+                        characterId: char._id,
+                        zoneId: CURRENT_TIER_ID,
+                        difficulty: MYTHIC_DIFFICULTY,
+                        partition: rankingPartition,
+                        "encounter.id": r.encounter.id,
+                        specName: specSlug,
+                        metric: "hps",
+                      },
+                      {
+                        characterId: char._id,
+                        wclCanonicalCharacterId: hpsCharacter.canonicalID,
+
+                        name: char.name,
+                        realm: char.realm,
+                        region: char.region,
+                        classID: char.classID,
+
+                        zoneId: CURRENT_TIER_ID,
+                        difficulty: MYTHIC_DIFFICULTY,
+                        partition: rankingPartition,
+                        metric: "hps",
+
+                        encounter: {
+                          id: r.encounter.id,
+                          name: r.encounter.name,
+                        },
+
+                        specName: rankingSpecSlug,
+                        role,
+
+                        bestSpecName: normalizedBestSpecName,
+
+                        rankPercent: r.rankPercent ?? 0,
+                        medianPercent: r.medianPercent ?? 0,
+                        lockedIn: r.lockedIn,
+                        totalKills: r.totalKills,
+                        bestAmount: r.bestAmount ?? 0,
+
+                        allStars: r.allStars
+                          ? {
+                              points: typeof r.allStars.points === "number" ? r.allStars.points : 0,
+                              possiblePoints: typeof r.allStars.possiblePoints === "number" ? r.allStars.possiblePoints : 0,
+                            }
+                          : { points: 0, possiblePoints: 0 },
+
+                        ilvl: r.bestRank?.ilvl,
+                      },
+                      { upsert: true, new: true },
+                    );
+                  }
+
+                  hasAnySpecRankings = true;
+                  logger.info(`[CharacterRankings] Updated HPS rankings for ${char.name} (${char.realm}) [spec: ${specSlug}]`);
+                }
+              }
             }
 
             if (hasAnySpecRankings) {
@@ -630,9 +815,10 @@ class CharacterService {
     logger.info("[Leaderboard] Starting leaderboard build...");
 
     try {
-      // Discover distinct encounters and partitions in the current tier
+      // Discover distinct encounters, partitions, and metrics in the current tier
       const encounterIds: number[] = await Ranking.distinct("encounter.id", { zoneId: CURRENT_TIER_ID, difficulty: MYTHIC_DIFFICULTY });
       const partitions: number[] = await Ranking.distinct("partition", { zoneId: CURRENT_TIER_ID, difficulty: MYTHIC_DIFFICULTY });
+
 
       logger.info(`[Leaderboard] Found ${encounterIds.length} encounters, ${partitions.length} partitions`);
 
@@ -650,10 +836,10 @@ class CharacterService {
 
       const entries: any[] = [];
 
-      // ── Boss leaderboards (per encounter × per partition) ──────────
+      // ── Boss leaderboards (per encounter × per partition × per metric) ─
       for (const encId of encounterIds) {
         for (const part of partitions) {
-          // Group by wclCanonicalCharacterId to keep only the best spec per character
+          // Group by (wclCanonicalCharacterId, metric) to keep only the best spec per character per metric
           const rows = await Ranking.aggregate([
             {
               $match: {
@@ -667,7 +853,7 @@ class CharacterService {
             { $sort: { bestAmount: -1, rankPercent: -1, totalKills: -1 } },
             {
               $group: {
-                _id: "$wclCanonicalCharacterId",
+                _id: { char: "$wclCanonicalCharacterId", metric: "$metric" },
                 characterId: { $first: "$characterId" },
                 wclCanonicalCharacterId: { $first: "$wclCanonicalCharacterId" },
                 name: { $first: "$name" },
@@ -677,6 +863,7 @@ class CharacterService {
                 specName: { $first: "$specName" },
                 bestSpecName: { $first: "$bestSpecName" },
                 role: { $first: "$role" },
+                metric: { $first: "$metric" },
                 ilvl: { $first: "$ilvl" },
                 bestAmount: { $first: "$bestAmount" },
                 encounterName: { $first: "$encounter.name" },
@@ -697,6 +884,7 @@ class CharacterService {
               type: "boss",
               encounterId: encId,
               partition: part,
+              metric: r.metric ?? "dps",
               characterId: r.characterId,
               wclCanonicalCharacterId: r.wclCanonicalCharacterId,
               name: r.name,
@@ -725,13 +913,13 @@ class CharacterService {
           }
         }
 
-        // Boss + all partitions (best per character across partitions)
+        // Boss + all partitions (best per character per metric across partitions)
         const bestPerChar = await Ranking.aggregate([
           { $match: { zoneId: CURRENT_TIER_ID, difficulty: MYTHIC_DIFFICULTY, "encounter.id": encId } },
           { $sort: { bestAmount: -1, rankPercent: -1, totalKills: -1, partition: -1 } },
           {
             $group: {
-              _id: "$wclCanonicalCharacterId",
+              _id: { char: "$wclCanonicalCharacterId", metric: "$metric" },
               characterId: { $first: "$characterId" },
               wclCanonicalCharacterId: { $first: "$wclCanonicalCharacterId" },
               name: { $first: "$name" },
@@ -741,6 +929,7 @@ class CharacterService {
               specName: { $first: "$specName" },
               bestSpecName: { $first: "$bestSpecName" },
               role: { $first: "$role" },
+              metric: { $first: "$metric" },
               ilvl: { $first: "$ilvl" },
               bestAmount: { $first: "$bestAmount" },
               encounterName: { $first: "$encounter.name" },
@@ -763,6 +952,7 @@ class CharacterService {
             type: "boss",
             encounterId: encId,
             partition: null,
+            metric: r.metric ?? "dps",
             characterId: r.characterId,
             wclCanonicalCharacterId: r.wclCanonicalCharacterId,
             name: r.name,
@@ -791,14 +981,14 @@ class CharacterService {
         }
       }
 
-      // ── AllStars leaderboards (per partition) ──────────────────────
+      // ── AllStars leaderboards (per partition × per metric) ────────────
       for (const part of partitions) {
         const allStarsAgg = await Ranking.aggregate([
           { $match: { zoneId: CURRENT_TIER_ID, difficulty: MYTHIC_DIFFICULTY, partition: part } },
           { $sort: { "allStars.points": -1 } },
           {
             $group: {
-              _id: { characterId: "$characterId", encounterId: "$encounter.id" },
+              _id: { characterId: "$characterId", encounterId: "$encounter.id", metric: "$metric" },
               characterId: { $first: "$characterId" },
               wclCanonicalCharacterId: { $first: "$wclCanonicalCharacterId" },
               name: { $first: "$name" },
@@ -807,6 +997,7 @@ class CharacterService {
               classID: { $first: "$classID" },
               specName: { $first: "$specName" },
               role: { $first: "$role" },
+              metric: { $first: "$metric" },
               points: { $first: "$allStars.points" },
               possiblePoints: { $first: "$allStars.possiblePoints" },
               ilvl: { $first: "$ilvl" },
@@ -817,7 +1008,7 @@ class CharacterService {
           },
           {
             $group: {
-              _id: "$_id.characterId",
+              _id: { characterId: "$_id.characterId", metric: "$_id.metric" },
               characterId: { $first: "$characterId" },
               wclCanonicalCharacterId: { $first: "$wclCanonicalCharacterId" },
               name: { $first: "$name" },
@@ -826,6 +1017,7 @@ class CharacterService {
               classID: { $first: "$classID" },
               specName: { $first: "$specName" },
               role: { $first: "$role" },
+              metric: { $first: "$metric" },
               points: { $sum: "$points" },
               possiblePoints: { $sum: "$possiblePoints" },
               ilvl: { $first: "$ilvl" },
@@ -853,6 +1045,7 @@ class CharacterService {
             type: "allstars",
             encounterId: null,
             partition: part,
+            metric: r.metric ?? "dps",
             characterId: r.characterId,
             wclCanonicalCharacterId: r.wclCanonicalCharacterId,
             name: r.name,
@@ -881,13 +1074,13 @@ class CharacterService {
         }
       }
 
-      // ── AllStars + all partitions (best per boss across partitions) ─
+      // ── AllStars + all partitions (best per boss per metric across partitions) ─
       const allStarsAllPartitions = await Ranking.aggregate([
         { $match: { zoneId: CURRENT_TIER_ID, difficulty: MYTHIC_DIFFICULTY } },
         { $sort: { "allStars.points": -1, partition: -1 } },
         {
           $group: {
-            _id: { wclCanonicalCharacterId: "$wclCanonicalCharacterId", encounterId: "$encounter.id" },
+            _id: { wclCanonicalCharacterId: "$wclCanonicalCharacterId", encounterId: "$encounter.id", metric: "$metric" },
             characterId: { $first: "$characterId" },
             wclCanonicalCharacterId: { $first: "$wclCanonicalCharacterId" },
             name: { $first: "$name" },
@@ -896,6 +1089,7 @@ class CharacterService {
             classID: { $first: "$classID" },
             specName: { $first: "$specName" },
             role: { $first: "$role" },
+            metric: { $first: "$metric" },
             points: { $first: "$allStars.points" },
             possiblePoints: { $first: "$allStars.possiblePoints" },
             ilvl: { $first: "$ilvl" },
@@ -906,7 +1100,7 @@ class CharacterService {
         },
         {
           $group: {
-            _id: "$_id.wclCanonicalCharacterId",
+            _id: { wclCanonicalCharacterId: "$_id.wclCanonicalCharacterId", metric: "$_id.metric" },
             characterId: { $first: "$characterId" },
             wclCanonicalCharacterId: { $first: "$wclCanonicalCharacterId" },
             name: { $first: "$name" },
@@ -915,6 +1109,7 @@ class CharacterService {
             classID: { $first: "$classID" },
             specName: { $first: "$specName" },
             role: { $first: "$role" },
+            metric: { $first: "$metric" },
             points: { $sum: "$points" },
             possiblePoints: { $sum: "$possiblePoints" },
             ilvl: { $first: "$ilvl" },
@@ -942,6 +1137,7 @@ class CharacterService {
           type: "allstars",
           encounterId: null,
           partition: null,
+          metric: r.metric ?? "dps",
           characterId: r.characterId,
           wclCanonicalCharacterId: r.wclCanonicalCharacterId,
           name: r.name,
@@ -1002,13 +1198,14 @@ class CharacterService {
     classId?: number;
     specName?: string;
     role?: "dps" | "healer" | "tank";
+    metric?: "dps" | "hps";
     partition?: number;
     limit?: number;
     page?: number;
     characterName?: string;
     guildName?: string;
   }): Promise<CharacterRankingsResponse> {
-    const { zoneId, encounterId, classId, specName, role, partition, limit = 100, page = 1, characterName, guildName } = options;
+    const { zoneId, encounterId, classId, specName, role, metric = "dps", partition, limit = 100, page = 1, characterName, guildName } = options;
 
     const MYTHIC_DIFFICULTY = 5;
     const normalizedSpecName = specName?.trim().toLowerCase();
@@ -1028,6 +1225,7 @@ class CharacterService {
       type: encounterId !== undefined ? "boss" : "allstars",
       encounterId: encounterId ?? null,
       partition: partition ?? null,
+      metric,
     };
 
     // ── Optional filters ─────────────────────────────────────────────
@@ -1103,6 +1301,7 @@ class CharacterService {
         context: {
           zoneId: e.zoneId,
           difficulty: e.difficulty,
+          metric: e.metric ?? "dps",
           partition: e.sourcePartition || e.partition,
           encounterId: e.encounterId,
           specName: e.specName,

--- a/backend/src/services/character.service.ts
+++ b/backend/src/services/character.service.ts
@@ -1230,8 +1230,90 @@ class CharacterService {
 
     // ── Optional filters ─────────────────────────────────────────────
     if (classId !== undefined) baseQuery.classID = classId;
-    if (normalizedSpecName !== undefined) baseQuery.specName = normalizedSpecName;
     if (normalizedRole !== undefined) baseQuery.role = normalizedRole;
+
+    // ── AllStars + spec filter: special in-memory path ───────────────
+    // The leaderboard stores one entry per character (best spec per boss in bossScores).
+    // Filtering by specName on the top-level field is unreliable because specName is
+    // chosen by $first (arbitrary). Instead, find entries where bossScores contains a
+    // non-zero score for the requested spec, filter bossScores in memory, and recompute
+    // the spec-specific allStars total.
+    if (encounterId === undefined && normalizedSpecName !== undefined) {
+      const specQuery = {
+        ...baseQuery,
+        bossScores: { $elemMatch: { specName: normalizedSpecName, points: { $gt: 0 } } },
+      };
+
+      const allSpecEntries = await CharacterLeaderboard.find(specQuery).lean() as any[];
+
+      for (const e of allSpecEntries) {
+        e.bossScores = (e.bossScores ?? []).filter((bs: any) => bs.specName === normalizedSpecName && bs.points > 0);
+        e.allStarsPoints = e.bossScores.reduce((sum: number, bs: any) => sum + (bs.points ?? 0), 0);
+        e.score = e.allStarsPoints;
+      }
+
+      allSpecEntries.sort((a: any, b: any) => b.score - a.score || (a.name ?? "").localeCompare(b.name ?? ""));
+
+      let displayEntries = allSpecEntries;
+      if (partialNameRegex) displayEntries = displayEntries.filter((e: any) => partialNameRegex.test(e.name ?? ""));
+      if (partialGuildNameRegex) displayEntries = displayEntries.filter((e: any) => partialGuildNameRegex!.test(e.guildName ?? ""));
+
+      const specTotalRanked = allSpecEntries.length;
+      const specTotalItems = displayEntries.length;
+      const specPage = Math.max(page, 1);
+      const specSkip = (specPage - 1) * safeLimit;
+      const pageEntries = displayEntries.slice(specSkip, specSkip + safeLimit);
+
+      const rankMap = new Map(allSpecEntries.map((e: any, i: number) => [e, i + 1]));
+
+      const data: CharacterRankingRow[] = pageEntries.map((e: any) => {
+        const guild = e.guildName && e.guildRealm ? { name: e.guildName, realm: e.guildRealm } : null;
+        const row: CharacterRankingRow = {
+          rank: rankMap.get(e) ?? 0,
+          character: {
+            wclCanonicalCharacterId: e.wclCanonicalCharacterId,
+            name: e.name,
+            realm: e.realm,
+            region: e.region,
+            classID: e.classID,
+            guild,
+          },
+          context: {
+            zoneId: e.zoneId,
+            difficulty: e.difficulty,
+            metric: e.metric ?? "dps",
+            partition: e.sourcePartition || e.partition,
+            encounterId: null,
+            specName: normalizedSpecName,
+            role: e.role,
+            ilvl: e.ilvl,
+          },
+          score: { type: "allStars", value: e.score },
+          stats: {
+            allStars: { points: e.allStarsPoints, possiblePoints: e.allStarsPossiblePoints },
+            rankPercent: e.rankPercent,
+            medianPercent: e.medianPercent,
+          },
+          updatedAt: e.updatedAt ? new Date(e.updatedAt).toISOString() : undefined,
+        };
+        if (e.bossScores?.length > 0) (row as any).bossScores = e.bossScores;
+        return row;
+      });
+
+      return {
+        data,
+        pagination: {
+          totalItems: specTotalItems,
+          totalRankedItems: specTotalRanked,
+          totalPages: Math.ceil(specTotalItems / safeLimit),
+          currentPage: specPage,
+          pageSize: safeLimit,
+        },
+      };
+    }
+
+    // Boss leaderboard or allStars without spec filter — use stored specName directly
+    if (normalizedSpecName !== undefined) baseQuery.specName = normalizedSpecName;
 
     // Total ranked items (before any name filter)
     const totalRankedItems = await CharacterLeaderboard.countDocuments(baseQuery);

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -555,7 +555,6 @@
     "placeholderAllBosses": "All bosses",
     "placeholderAllPatches": "All patches",
     "allClasses": "All classes",
-    "allRoles": "All roles",
     "searchPlaceholder": "Search character",
     "searchGuildPlaceholder": "Search guild",
     "columnRank": "Rank",
@@ -563,6 +562,7 @@
     "columnGuild": "Guild",
     "columnIlvl": "Ilvl",
     "columnDps": "DPS",
+    "columnHps": "HPS",
     "columnScore": "Score"
   }
 }

--- a/frontend/messages/fi.json
+++ b/frontend/messages/fi.json
@@ -555,7 +555,6 @@
     "placeholderAllBosses": "Kaikki pomot",
     "placeholderAllPatches": "Kaikki päivitykset",
     "allClasses": "Kaikki luokat",
-    "allRoles": "Kaikki roolit",
     "searchPlaceholder": "Hae hahmoa",
     "searchGuildPlaceholder": "Hae kiltaa",
     "columnRank": "Sija",
@@ -563,6 +562,7 @@
     "columnGuild": "Kilta",
     "columnIlvl": "Ilvl",
     "columnDps": "DPS",
+    "columnHps": "HPS",
     "columnScore": "Pisteet"
   }
 }

--- a/frontend/src/app/character-rankings/page.tsx
+++ b/frontend/src/app/character-rankings/page.tsx
@@ -10,7 +10,7 @@ type Filters = {
   encounterId?: number;
   classId?: number | null;
   specName?: string | null;
-  role?: "dps" | "healer" | "tank" | null;
+  metric?: "dps" | "hps";
   page?: number;
   limit?: number;
   partition?: number | null;

--- a/frontend/src/components/RankingTableWrapper.tsx
+++ b/frontend/src/components/RankingTableWrapper.tsx
@@ -747,7 +747,7 @@ export function RankingTableWrapper({ data, bosses, partitionOptions = [], showP
           </div>
 
           {/* Metric Selector */}
-          <div className="min-w-[100px]">
+          <div className="min-w-[120px]">
             <MetricSelector selectedMetric={selectedMetric} onChange={handleMetricChange} />
           </div>
 

--- a/frontend/src/components/RankingTableWrapper.tsx
+++ b/frontend/src/components/RankingTableWrapper.tsx
@@ -29,7 +29,7 @@ interface RankingTableWrapperProps {
     encounterId?: number;
     classId?: number | null;
     specName?: string | null;
-    role?: "dps" | "healer" | "tank" | null;
+    metric?: "dps" | "hps";
     partition?: number | null;
     characterName?: string | null;
     guildName?: string | null;
@@ -41,7 +41,7 @@ type RankingFilters = {
   encounterId?: number;
   classId?: number | null;
   specName?: string | null;
-  role?: "dps" | "healer" | "tank" | null;
+  metric?: "dps" | "hps";
   partition?: number | null;
   characterName?: string | null;
   guildName?: string | null;
@@ -149,7 +149,7 @@ function ClassSpecButton({ selectedClass, selectedSpec, allClassesLabel, onToggl
     <button
       type="button"
       onClick={onToggle}
-      className="relative w-full min-h-10 cursor-default rounded-md bg-gray-800 py-2 pl-3 pr-10 text-left text-white shadow-md focus:outline-none focus:ring-2 focus:ring-blue-500 sm:text-sm font-bold"
+      className="relative w-full min-h-10 cursor-default rounded-md bg-gray-800 py-2 pl-3 pr-10 text-left text-white shadow-md focus:outline-none focus:ring-2 focus:ring-blue-500 sm:text-sm font-bold whitespace-nowrap overflow-hidden"
     >
       <div className="flex items-center gap-3">
         {icon ? (
@@ -330,7 +330,7 @@ type BuildRankingColumnsOptions = {
   currentPage: number;
   pageSize: number;
   selectedSpec: string | null;
-  selectedRole: "dps" | "healer" | "tank" | null;
+  selectedMetric: "dps" | "hps";
   t: (key: string) => string;
 };
 
@@ -342,7 +342,7 @@ function formatRealmSlug(realm: string) {
     .join(" ");
 }
 
-function buildRankingColumns({ selectedBoss, bosses, currentPage, pageSize, selectedSpec, selectedRole, t }: BuildRankingColumnsOptions): ColumnDef<CharacterRankingRow>[] {
+function buildRankingColumns({ selectedBoss, bosses, currentPage, pageSize, selectedSpec, selectedMetric, t }: BuildRankingColumnsOptions): ColumnDef<CharacterRankingRow>[] {
   const isShowingDamage = selectedBoss !== null;
   const showIlvl = isShowingDamage;
 
@@ -364,9 +364,9 @@ function buildRankingColumns({ selectedBoss, bosses, currentPage, pageSize, sele
         const wclUrl = `https://www.warcraftlogs.com/character/eu/${encodeURIComponent(realm)}/${encodeURIComponent(name)}`;
         const classIcon = getClassInfoById(row.character.classID)?.iconUrl;
         const roleSpecName = isShowingDamage ? row.context.specName : row.context.bestSpecName ?? row.context.specName;
-        const roleSpecIcon = selectedRole && roleSpecName ? getSpecIconUrl(row.character.classID, roleSpecName) : null;
+        const roleSpecIcon = selectedMetric === "hps" && roleSpecName ? getSpecIconUrl(row.character.classID, roleSpecName) : null;
         const primaryIcon = roleSpecIcon ?? classIcon;
-        const specIcon = !selectedRole && isShowingDamage && row.context.specName ? getSpecIconUrl(row.character.classID, row.context.specName) : null;
+        const specIcon = selectedMetric !== "hps" && isShowingDamage && row.context.specName ? getSpecIconUrl(row.character.classID, row.context.specName) : null;
 
         return (
           <div className="flex justify-between items-center">
@@ -418,7 +418,7 @@ function buildRankingColumns({ selectedBoss, bosses, currentPage, pageSize, sele
 
   columns.push({
     id: "metric",
-    header: isShowingDamage ? t("columnDps") : t("columnScore"),
+    header: isShowingDamage ? (selectedMetric === "hps" ? t("columnHps") : t("columnDps")) : t("columnScore"),
     shrink: true,
     accessor: (row: CharacterRankingRow) => {
       const value = isShowingDamage ? row.stats.bestAmount?.toFixed(1) : row.stats.allStars?.points?.toFixed(1);
@@ -487,38 +487,37 @@ function MobileBossScores({ row, bosses, selectedSpec }: { row: CharacterRanking
   );
 }
 
-const ROLE_OPTIONS = [
+const METRIC_OPTIONS = [
   { value: "dps" as const, label: "DPS", icon: "/icons/roleicon_damage.png" },
-  { value: "healer" as const, label: "Healer", icon: "/icons/roleicon_healer.png" },
-  { value: "tank" as const, label: "Tank", icon: "/icons/roleicon_tank.png" },
+  { value: "hps" as const, label: "HPS", icon: "/icons/roleicon_healer.png" },
 ];
 
-type RoleSelectorProps = {
-  selectedRole: "dps" | "healer" | "tank" | null;
-  allRolesLabel: string;
-  onChange: (role: "dps" | "healer" | "tank" | null) => void;
+type MetricSelectorProps = {
+  selectedMetric: "dps" | "hps";
+  onChange: (metric: "dps" | "hps") => void;
 };
 
-function RoleSelector({ selectedRole, allRolesLabel, onChange }: RoleSelectorProps) {
-  const activeOption = ROLE_OPTIONS.find((o) => o.value === selectedRole) ?? null;
+function MetricSelector({ selectedMetric, onChange }: MetricSelectorProps) {
+  const activeOption = METRIC_OPTIONS.find((o) => o.value === selectedMetric) ?? METRIC_OPTIONS[0];
 
   return (
     <Selector
-      items={ROLE_OPTIONS}
+      items={METRIC_OPTIONS}
       selectedItem={activeOption}
-      onChange={(opt) => onChange(opt?.value ?? null)}
-      placeholder={allRolesLabel}
+      onChange={(opt) => onChange(opt?.value ?? "dps")}
+      nullable={false}
+      placeholder="DPS"
       renderButton={(opt) => (
         <div className="flex items-center gap-2">
-          <Image src={opt!.icon} alt={opt!.label} width={22} height={22} />
-          {opt!.label}
+          <Image src={opt!.icon} alt={opt!.label} width={18} height={18} />
+          <span>{opt!.label}</span>
         </div>
       )}
       renderOption={(opt) => (
-        <>
-          <Image src={opt.icon} alt={opt.label} width={22} height={22} />
-          {opt.label}
-        </>
+        <div className="flex items-center gap-2">
+          <Image src={opt.icon} alt={opt.label} width={18} height={18} />
+          <span>{opt.label}</span>
+        </div>
       )}
     />
   );
@@ -532,7 +531,7 @@ export function RankingTableWrapper({ data, bosses, partitionOptions = [], showP
   const [selectedPartition, setSelectedPartition] = useState<PatchPartitionOption | null>(null);
   const [searchValue, setSearchValue] = useState("");
   const [guildSearchValue, setGuildSearchValue] = useState("");
-  const [selectedRole, setSelectedRole] = useState<"dps" | "healer" | "tank" | null>(null);
+  const [selectedMetric, setSelectedMetric] = useState<"dps" | "hps">("dps");
   const searchInitializedRef = useRef(false);
   const guildSearchInitializedRef = useRef(false);
   const searchDebounceRef = useRef<number | null>(null);
@@ -545,7 +544,7 @@ export function RankingTableWrapper({ data, bosses, partitionOptions = [], showP
         encounterId: selectedBoss?.id,
         classId: selectedClass?.id ?? null,
         specName: selectedSpec,
-        role: selectedRole,
+        metric: selectedMetric,
         partition: selectedPartition?.value ?? null,
         characterName: searchValue.trim() || null,
         guildName: guildSearchValue.trim() || null,
@@ -553,7 +552,7 @@ export function RankingTableWrapper({ data, bosses, partitionOptions = [], showP
         ...overrides,
       });
     },
-    [onFiltersChange, selectedBoss?.id, selectedClass?.id, selectedPartition?.value, selectedRole, selectedSpec, searchValue, guildSearchValue],
+    [onFiltersChange, selectedBoss?.id, selectedClass?.id, selectedPartition?.value, selectedMetric, selectedSpec, searchValue, guildSearchValue],
   );
 
   useEffect(() => {
@@ -639,28 +638,23 @@ export function RankingTableWrapper({ data, bosses, partitionOptions = [], showP
     applyFilters({ partition: partition?.value ?? null, page: 1 });
   };
 
-  const handleRoleChange = (role: "dps" | "healer" | "tank" | null) => {
-    setSelectedRole(role);
+  const handleMetricChange = (metric: "dps" | "hps") => {
+    setSelectedMetric(metric);
 
-    if (!role) {
-      applyFilters({ role: null, page: 1 });
-      return;
+    // When switching to HPS, clear any class/spec selection that isn't a healer
+    if (metric === "hps" && selectedClass) {
+      const hasHealerSpec = selectedClass.specs.some((spec) => spec.role === "healer");
+      const isSpecHealer = selectedSpec ? selectedClass.specs.some((spec) => spec.name === selectedSpec && spec.role === "healer") : false;
+
+      if ((selectedSpec && !isSpecHealer) || (!selectedSpec && !hasHealerSpec)) {
+        setSelectedClass(null);
+        setSelectedSpec(null);
+        applyFilters({ metric, classId: null, specName: null, page: 1 });
+        return;
+      }
     }
 
-    const isCurrentSelectionCompatibleWithRole = !selectedClass
-      ? true
-      : selectedSpec
-        ? selectedClass.specs.some((spec) => spec.name === selectedSpec && spec.role === role)
-        : selectedClass.specs.some((spec) => spec.role === role);
-
-    if (isCurrentSelectionCompatibleWithRole) {
-      applyFilters({ role, page: 1 });
-      return;
-    }
-
-    setSelectedClass(null);
-    setSelectedSpec(null);
-    applyFilters({ role, classId: null, specName: null, page: 1 });
+    applyFilters({ metric, page: 1 });
   };
 
   const handlePageChange = (page: number) => {
@@ -684,10 +678,10 @@ export function RankingTableWrapper({ data, bosses, partitionOptions = [], showP
       currentPage,
       pageSize,
       selectedSpec,
-      selectedRole,
+      selectedMetric,
       t,
     });
-  }, [pagination?.currentPage, pagination?.pageSize, selectedBoss, bosses, selectedSpec, selectedRole, t]);
+  }, [pagination?.currentPage, pagination?.pageSize, selectedBoss, bosses, selectedSpec, selectedMetric, t]);
 
   const title = selectedBoss ? `${t("titleForBoss")} ${selectedBoss.name}` : t("titleAllStars");
 
@@ -696,74 +690,78 @@ export function RankingTableWrapper({ data, bosses, partitionOptions = [], showP
       {error ? <div className="rounded-md border border-red-500/40 bg-red-950/30 px-4 py-3 text-red-200">{error}</div> : null}
       <div className="flex flex-wrap items-center justify-between gap-4">
         <h2 className="text-xl font-semibold text-white">{title}</h2>
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-6 gap-3 w-full">
+        <div className="flex flex-wrap gap-3 w-full">
           {/* Character Search */}
-          <div className="w-full">
-            <input
-              type="text"
-              value={searchValue}
-              onChange={(event) => setSearchValue(event.target.value)}
-              maxLength={64}
-              placeholder={t("searchPlaceholder")}
-              className="w-full min-h-10 rounded-md bg-gray-800 py-2 px-3 text-white shadow-md placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 sm:text-sm font-bold"
-            />
-          </div>
+          <input
+            type="text"
+            value={searchValue}
+            onChange={(event) => setSearchValue(event.target.value)}
+            maxLength={64}
+            placeholder={t("searchPlaceholder")}
+            className="flex-1 min-w-[160px] min-h-10 rounded-md bg-gray-800 py-2 px-3 text-white shadow-md placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 sm:text-sm font-bold whitespace-nowrap"
+          />
 
           {/* Guild Search */}
-          <div className="w-full">
-            <input
-              type="text"
-              value={guildSearchValue}
-              onChange={(event) => setGuildSearchValue(event.target.value)}
-              maxLength={64}
-              placeholder={t("searchGuildPlaceholder")}
-              className="w-full min-h-10 rounded-md bg-gray-800 py-2 px-3 text-white shadow-md placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 sm:text-sm font-bold"
+          <input
+            type="text"
+            value={guildSearchValue}
+            onChange={(event) => setGuildSearchValue(event.target.value)}
+            maxLength={64}
+            placeholder={t("searchGuildPlaceholder")}
+            className="flex-1 min-w-[160px] min-h-10 rounded-md bg-gray-800 py-2 px-3 text-white shadow-md placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 sm:text-sm font-bold whitespace-nowrap"
+          />
+
+          {/* Boss Selector */}
+          <div className="flex-1 min-w-[160px]">
+            <Selector
+              items={bosses}
+              selectedItem={selectedBoss}
+              onChange={handleBossChange}
+              placeholder={t("placeholderAllBosses")}
+              renderButton={(boss) => (
+                <div className="flex items-center gap-2 whitespace-nowrap">
+                  <IconImage iconFilename={boss?.iconUrl} alt={`${boss?.name} icon`} width={24} height={24} />
+                  {boss?.name}
+                </div>
+              )}
+              renderOption={(boss) => (
+                <>
+                  <IconImage iconFilename={boss.iconUrl} alt={`${boss.name} icon`} width={24} height={24} />
+                  {boss.name}
+                </>
+              )}
             />
           </div>
 
-          {/* Boss Selector */}
-          <Selector
-            items={bosses}
-            selectedItem={selectedBoss}
-            onChange={handleBossChange}
-            placeholder={t("placeholderAllBosses")}
-            renderButton={(boss) => (
-              <div className="flex items-center gap-2">
-                <IconImage iconFilename={boss?.iconUrl} alt={`${boss?.name} icon`} width={24} height={24} />
-                {boss?.name}
-              </div>
-            )}
-            renderOption={(boss) => (
-              <>
-                <IconImage iconFilename={boss.iconUrl} alt={`${boss.name} icon`} width={24} height={24} />
-                {boss.name}
-              </>
-            )}
-          />
-
           {/* Class / Spec Selector */}
-          <ClassSpecSelector
-            selectedClass={selectedClass}
-            selectedSpec={selectedSpec}
-            selectedRole={selectedRole}
-            allClassesLabel={t("allClasses")}
-            onClassSelect={handleClassChange}
-            onSpecSelect={handleSpecSelect}
-            onClear={clearClassAndSpec}
-          />
+          <div className="flex-1 min-w-[160px]">
+            <ClassSpecSelector
+              selectedClass={selectedClass}
+              selectedSpec={selectedSpec}
+              selectedRole={selectedMetric === "hps" ? "healer" : null}
+              allClassesLabel={t("allClasses")}
+              onClassSelect={handleClassChange}
+              onSpecSelect={handleSpecSelect}
+              onClear={clearClassAndSpec}
+            />
+          </div>
 
-          {/* Role Selector */}
-          <RoleSelector selectedRole={selectedRole} allRolesLabel={t("allRoles")} onChange={handleRoleChange} />
+          {/* Metric Selector */}
+          <div className="min-w-[100px]">
+            <MetricSelector selectedMetric={selectedMetric} onChange={handleMetricChange} />
+          </div>
 
           {showPartitionSelector && (
-            <Selector
-              items={partitionOptions}
-              selectedItem={selectedPartition}
-              onChange={handlePartitionChange}
-              placeholder={t("placeholderAllPatches")}
-              renderButton={(partition) => <span>{partition?.label}</span>}
-              renderOption={(partition) => <span>{partition.label}</span>}
-            />
+            <div className="flex-1 min-w-[160px]">
+              <Selector
+                items={partitionOptions}
+                selectedItem={selectedPartition}
+                onChange={handlePartitionChange}
+                placeholder={t("placeholderAllPatches")}
+                renderButton={(partition) => <span className="whitespace-nowrap">{partition?.label}</span>}
+                renderOption={(partition) => <span>{partition.label}</span>}
+              />
+            </div>
           )}
         </div>
       </div>

--- a/frontend/src/components/Selector.tsx
+++ b/frontend/src/components/Selector.tsx
@@ -10,27 +10,30 @@ interface SelectorProps<T> {
   renderButton: (item: T | null) => ReactNode;
   renderOption: (item: T, selected: boolean) => ReactNode;
   placeholder?: string;
+  nullable?: boolean;
 }
 
-export function Selector<T>({ items, selectedItem, onChange, renderButton, renderOption, placeholder = "Select..." }: SelectorProps<T>) {
+export function Selector<T>({ items, selectedItem, onChange, renderButton, renderOption, placeholder = "Select...", nullable = true }: SelectorProps<T>) {
   return (
     <Listbox value={selectedItem} onChange={onChange}>
       <div className="relative w-full">
-        <ListboxButton className="relative w-full min-h-[40px] cursor-default rounded-md bg-gray-800 py-2 pl-3 pr-10 text-left text-white shadow-md focus:outline-none focus:ring-2 focus:ring-blue-500 sm:text-sm font-bold">
+        <ListboxButton className="relative w-full min-h-[40px] cursor-default rounded-md bg-gray-800 py-2 pl-3 pr-10 text-left text-white shadow-md focus:outline-none focus:ring-2 focus:ring-blue-500 sm:text-sm font-bold whitespace-nowrap overflow-hidden text-ellipsis">
           {selectedItem ? renderButton(selectedItem) : placeholder}
         </ListboxButton>
         <ListboxOptions className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-gray-800 py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm font-bold">
-          <ListboxOption
-            value={null}
-            className={({ active }) => `relative cursor-default select-none py-2 pl-10 pr-4 font-bold ${active ? "bg-blue-600 text-white" : "text-gray-300"}`}
-          >
-            {({ selected }) => (
-              <div className="flex items-center gap-2">
-                {placeholder}
-                {selected && <span className="absolute inset-y-0 left-0 flex items-center pl-3 text-blue-400">✓</span>}
-              </div>
-            )}
-          </ListboxOption>
+          {nullable && (
+            <ListboxOption
+              value={null}
+              className={({ active }) => `relative cursor-default select-none py-2 pl-10 pr-4 font-bold ${active ? "bg-blue-600 text-white" : "text-gray-300"}`}
+            >
+              {({ selected }) => (
+                <div className="flex items-center gap-2">
+                  {placeholder}
+                  {selected && <span className="absolute inset-y-0 left-0 flex items-center pl-3 text-blue-400">✓</span>}
+                </div>
+              )}
+            </ListboxOption>
+          )}
           {items.map((item, idx) => (
             <ListboxOption
               key={idx}


### PR DESCRIPTION
## Add metric field (dps/hps) to Ranking and CharacterLeaderboard models with updated unique indexes
- Fetch HPS rankings separately for healer specs via WarcraftLogs API
- Expose metric query param in character rankings route
- Replace role filter with DPS/HPS metric selector in the frontend

---

## Fix AllStars spec filter by querying bossScores instead of top-level specName
- oli rikki kun näytti jotai resto shamanin rankkei vaiks oli elemental filter päällä. Toimii nyt. 

---

Pitää ajaa kaikki `rankings` uudelleen ja varmaan joudut poistaa pari indeksiä siit `rankings` taulusta. Vois melkee vaa poistaa koko taulun ja ajaa uusiks
